### PR TITLE
Fix syntax error in utils.py

### DIFF
--- a/d6tstack/utils.py
+++ b/d6tstack/utils.py
@@ -62,7 +62,7 @@ def pd_readsql_table_from_sqlengine(uri, table_name, schema_name=None, connect_a
 
     """
 
-    return pd_readsql_query_from_sqlengine(uri, "SELECT * FROM {};".fromat(table_name), schema_name=schema_name, connect_args=connect_args)
+    return pd_readsql_query_from_sqlengine(uri, "SELECT * FROM {};".format(table_name), schema_name=schema_name, connect_args=connect_args)
 
 
 @d6tcollect.collect


### PR DESCRIPTION
Change string.fromat() to string.format()